### PR TITLE
Added -global to conflicting names

### DIFF
--- a/cfn-global.yml
+++ b/cfn-global.yml
@@ -40,7 +40,7 @@ Resources:
   EventRuleCTChange:
     Type: "AWS::Events::Rule"
     Properties:
-      Name: "detect-cloudtrail-changes"
+      Name: "detect-cloudtrail-changes-global"
       Description: !Sub "[${Project}] Monitor change on CloudTrail setup"
       State: "ENABLED"
       Targets:
@@ -135,7 +135,7 @@ Resources:
     Type: "AWS::SNS::Topic"
     Properties:
       DisplayName: !Sub "[${AWS::AccountId}] Security Alarm"
-      TopicName: !Sub "${Project}-alarm-topic-${AWS::Region}"
+      TopicName: !Sub "${Project}-alarm-topic-${AWS::Region}-global"
       Subscription:
         - Protocol: email
           Endpoint: !Ref AlarmRecipient


### PR DESCRIPTION
Hey, thanks for making this open-source!

Currently, trying to deploy the local template to us-east-1 (which is my primary region) fails due to 2 resource conflicts from the global template. A quick and simple fix is to add `-global` at the end of the duplicate resources in the global template (`detect-cloudtrail-changes-global`) and (`${Project}-alarm-topic-${AWS::Region}-global`). 

It does create a redundant resource (The `AWS::Events::Rule` for detecting CT changes) in us-east-1, but I don't think users will mind considering it doesn't increase pricing or alert noise in any meaningful way. If you don't think this is an acceptable fix, I don't mind thinking through alternatives!