### PR TITLE
Metric and alarm for GetFileDownloadUrls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following suspicious activities are currently supported:
 9. AMI Exfiltration (`ModifyImageAttribute`)
 10. Who Am I Calls (`GetCallerIdentity`)
 11. IMDSv1 RunInstances (`RunInstances` && `optional` http tokens)
+12. CloudShell Exfiltration (`GetFileDownloadUrls`)
 
 ## :keyboard: Usage
 

--- a/cfn-local.yml
+++ b/cfn-local.yml
@@ -179,6 +179,36 @@ Resources:
           MetricNamespace: "CloudTrailMetrics"
           MetricName: "IMDSv1RunInstance"
 
+  CloudWatchLogsMetricsFilterCloudShellGetFileDownloadUrls:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CTLogGroupName
+      FilterPattern: '{ ($.eventName = GetFileDownloadUrls) }'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: "CloudTrailMetrics"
+          MetricName: "CloudShellGetFileDownloadUrls"
+          DefaultValue: 0
+
+  AlarmCloudShellGetFiledownloadUrls:
+    # Can detect data exfil through CloudShell (ie: scrape and download credentials stored in Secrets Manager)
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "CloudShell GetFileDownloadUrls"
+      AlarmActions:
+        - !Ref CtAlertingTopic
+      AlarmDescription: >
+        Alarm on CloudShell GetFileDownloadUrls
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: "CloudShellGetFileDownloadUrls"
+      Namespace: "CloudTrailMetrics"
+      Period: "300"
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: "notBreaching"
+
   CtAlertingTopic:
     # https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
     Type: "AWS::SNS::Topic"


### PR DESCRIPTION
Resolves #16 

Adds a metric and alarm for CloudShell GetFileDownloadUrls which can be used by threat actors to exfil data (like credentials in Secrets Manager). It's been actively used by LUCR-3. Credit: Ian Ahl for Permiso Security for the tip.