### PR TITLE
Detect CloudShell GetFileDownloadUrls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following suspicious activities are currently supported:
 9. AMI Exfiltration (`ModifyImageAttribute`)
 10. Who Am I Calls (`GetCallerIdentity`)
 11. IMDSv1 RunInstances (`RunInstances` && `optional` http tokens)
+12. CloudShell Exfiltration (`GetFileDownloadUrls`)
 
 ## :keyboard: Usage
 

--- a/cfn-local.yml
+++ b/cfn-local.yml
@@ -179,6 +179,36 @@ Resources:
           MetricNamespace: "CloudTrailMetrics"
           MetricName: "IMDSv1RunInstance"
 
+  CloudWatchLogsMetricsFilterCloudShellGetFileDownloadUrls:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: !Ref CTLogGroupName
+      FilterPattern: '{ ($.eventName = GetFileDownloadUrls) }'
+      MetricTransformations:
+        - MetricValue: "1"
+          MetricNamespace: "CloudTrailMetrics"
+          MetricName: "CloudShellGetFileDownloadUrls"
+          DefaultValue: 0
+
+  AlarmCloudShellGetFiledownloadUrls:
+    # Can detect data exfil through CloudShell (ie: scrape and download credentials stored in Secrets Manager)
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmName: !Sub "CloudShell GetFileDownloadUrls"
+      AlarmActions:
+        - !Ref CtAlertingTopic
+      AlarmDescription: >
+        Alarm on CloudShell GetFileDownloadUrls
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: "CloudShellGetFileDownloadUrls"
+      Namespace: "CloudTrailMetrics"
+      Period: "300"
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: "notBreaching"
+
   CtAlertingTopic:
     # https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
     Type: "AWS::SNS::Topic"

--- a/cfn-local.yml
+++ b/cfn-local.yml
@@ -98,6 +98,28 @@ Resources:
           eventName:
             - "GetCallerIdentity"
 
+  EventRuleCloudShellGetFileDownloadUrls:
+    # Can detect data exfil through CloudShell (ie: scrape and download credentials stored in Secrets Manager)
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Sub "${Project}-detect-cloudshell-getfiledownloadurls"
+      Description: !Sub "[${Project}] Detect CloudShell GetFileDownloadUrls"
+      State: "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+      EventPattern:
+        source:
+          - aws.cloudshell
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "cloudshell.amazonaws.com"
+          eventName:
+            - "GetFileDownloadUrls"
+
   CloudWatchLogsMetricsFilterAccessDenied:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -178,36 +200,6 @@ Resources:
         - MetricValue: "1"
           MetricNamespace: "CloudTrailMetrics"
           MetricName: "IMDSv1RunInstance"
-
-  CloudWatchLogsMetricsFilterCloudShellGetFileDownloadUrls:
-    Type: AWS::Logs::MetricFilter
-    Properties:
-      LogGroupName: !Ref CTLogGroupName
-      FilterPattern: '{ ($.eventName = GetFileDownloadUrls) }'
-      MetricTransformations:
-        - MetricValue: "1"
-          MetricNamespace: "CloudTrailMetrics"
-          MetricName: "CloudShellGetFileDownloadUrls"
-          DefaultValue: 0
-
-  AlarmCloudShellGetFiledownloadUrls:
-    # Can detect data exfil through CloudShell (ie: scrape and download credentials stored in Secrets Manager)
-    Type: "AWS::CloudWatch::Alarm"
-    Properties:
-      ActionsEnabled: true
-      AlarmName: !Sub "CloudShell GetFileDownloadUrls"
-      AlarmActions:
-        - !Ref CtAlertingTopic
-      AlarmDescription: >
-        Alarm on CloudShell GetFileDownloadUrls
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      EvaluationPeriods: 1
-      MetricName: "CloudShellGetFileDownloadUrls"
-      Namespace: "CloudTrailMetrics"
-      Period: "300"
-      Statistic: Sum
-      Threshold: 1
-      TreatMissingData: "notBreaching"
 
   CtAlertingTopic:
     # https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/


### PR DESCRIPTION
Closes #16 

Enables detecting GetFileDownloadUrls in CloudShell which could be used by threat actors to exfiltrate sensitive data from an AWS environment. Tactic actively being used by LUCR-3. Source: Ian Ahl from Permiso Security