### PR TITLE
Implement issue #32 detections + hardening, security-review fixes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,121 @@
+# AGENT.md
+
+Guidance for AI coding agents (Cursor, Claude Code, and similar) working in this repository. Humans should read `README.md` first.
+
+## What this project is
+
+The AWS Security Survival Kit (ASSK) is two CloudFormation stacks that wire EventBridge rules and CloudWatch alarms into an SNS topic to send actionable security alerts about an AWS account. It is intentionally small.
+
+The goal: *"I would notice within minutes if something obviously bad happens in this AWS account"*, without paying for a SIEM. ASSK complements GuardDuty. It is not a SIEM, a SOAR, a remediation engine, or a multi-account orchestrator.
+
+### Design principles (do not violate without discussion)
+
+1. **Free or near-free.** Everything is serverless and pay-per-use. Typical accounts pay cents per month. New features must not push that into dollars without a clear opt-in flag and a documented cost note.
+2. **No agents, no extra accounts, no SaaS.** Deploys into the account being monitored. No Lambda functions, no containers, no third-party integrations.
+3. **Actionable alerts.** Every notification is a small structured payload (event name, account, region, principal, source IP), formatted via `InputTransformer`. Never ship a rule that delivers raw CloudTrail JSON.
+4. **Secure by default.** `make deploy` hardens the account before deploying the alerting stacks, and the alerting stacks themselves enable termination protection.
+5. **Complements GuardDuty.** Do not duplicate what GuardDuty already covers. Focus on tampering and high-signal events GuardDuty misses.
+
+## Repository layout
+
+```
+.
+├── Makefile          # Entry point. Holds all per-deployment variables.
+├── cfn-local.yml     # Regional stack: most EventBridge rules + CW alarms + SNS topic + optional CMK.
+├── cfn-global.yml    # us-east-1 stack: global-service events (IAM, Organizations, ...) + SNS topic + optional CMK.
+├── README.md         # User-facing documentation. MUST stay in sync with the templates and the Makefile.
+├── AGENT.md          # This file. MUST stay in sync with project conventions.
+├── LICENSE
+└── assets/           # Screenshots referenced from README.md.
+```
+
+## Requirements
+
+- **AWS CLI v2.**
+- **`make`.**
+- **`cfn-lint`** for template validation (`pip install cfn-lint` or `brew install cfn-lint`).
+- **AWS credentials in the environment.** Either a named profile (`Profile` in `Makefile`) or env-injected credentials (`aws-vault exec`, IRSA, ECS task role, ...). The `Makefile` detects an empty `Profile` and omits the `--profile` flag, so both styles work.
+- **A pre-existing CloudTrail trail** delivering to a CloudWatch Logs `LogGroup`. The `LogGroup` name is `CTLogGroupName`, the region is `LocalAWSRegion`.
+
+## Common commands
+
+```sh
+cfn-lint cfn-local.yml cfn-global.yml         # validate templates
+make -n deploy                                # show what `deploy` would run (recommended before any non-trivial change)
+make account_level_security                   # cross-region account hardening only
+make deploy                                   # hardening + both stacks + termination protection
+make tear-down                                # disable protection + delete both stacks
+```
+
+For large templates (`cfn-local.yml` is already above the 51,200-byte inline CloudFormation deploy limit), set `LocalS3Bucket` and `GlobalS3Bucket` Makefile variables to existing buckets in the relevant regions. The deploy command then automatically uses `--s3-bucket ... --s3-prefix assk`.
+
+## Conventions
+
+### Adding a new EventBridge rule
+
+1. **Choose the right template.**
+   - `cfn-local.yml` for any regional service event (EC2, S3, Lambda, KMS, ...).
+   - `cfn-global.yml` for global-service events (IAM, Organizations, Route 53 hosted zones, ...). Global-service CloudTrail events only surface in `us-east-1`.
+2. **Always-on vs opt-in.**
+   - Always-on is allowed only when the rule is genuinely high-signal and low-noise in any AWS account. When in doubt, make it opt-in.
+   - Opt-in rules are introduced as a CloudFormation `Parameter` named `Enable<Name>Detection`, `Type: String`, `AllowedValues: ["true", "false"]`, `Default: "false"`, backed by a `Condition` named `<Name>DetectionEnabled`, and gated on the rule resource via `Condition: <Name>DetectionEnabled`.
+3. **`EventPattern`.**
+   - Prefer `prefix` matchers on `eventName` when AWS may add version suffixes (most of Lambda, some IAM).
+   - Validate the pattern. EventBridge silently matches nothing for invalid patterns. (We caught a `"*.*.*.*/*"` bug this way.)
+   - Use `wildcard` matchers for ARNs and other glob-like shapes.
+4. **`InputTransformer`.** Every rule MUST use the project's emoji-keyed `InputTemplate`. Look at `EventRuleConfigChanges` or `EventRuleSecurityGroupChanges` for the canonical pattern. Raw CloudTrail blobs in alerts are not acceptable.
+5. **Target.** The stack's existing `CtAlertingTopic` SNS topic. Do not create per-rule topics.
+
+### Adding a new parameter
+
+1. Declare it in the relevant template's `Parameters` block with a clear `Description` and a sensible `Default`.
+2. If it is a boolean toggle, use `Type: String` with `AllowedValues: ["true", "false"]`, paired with a `Condition`.
+3. Plumb it through the `Makefile`: add a variable at the top of the file, then add the corresponding `<Name>=<value>` entry to the `--parameter-overrides` block in `deploy`.
+4. Document it in `README.md` in the Parameters section.
+
+### KMS and SNS
+
+- The optional SNS CMK exists per stack (regional and `us-east-1`). The key policy must keep `events.amazonaws.com`, `cloudwatch.amazonaws.com`, and `chatbot.amazonaws.com` as `Service` principals with `kms:Decrypt` and `kms:GenerateDataKey*`. Removing any of these breaks alert delivery or Chatbot integration.
+- The SNS topic policy must not grant `sns:Subscribe` via `Principal: "*"`. Subscribing happens through IAM permissions, not through the topic policy. Adding it back is a regression and a real exfiltration risk.
+
+### Account-level hardening (`account_level_security` target)
+
+- EBS default encryption, public AMI block, public snapshot block, and IMDSv2 default are **region-scoped APIs**. They must run in every enabled region, fetched via `aws ec2 describe-regions --filter Name=opt-in-status,Values=opt-in-not-required,opted-in`.
+- S3 Block Public Access is **account-scoped** (single call), no loop needed.
+- Per-call CLI timeouts (`--cli-connect-timeout 10 --cli-read-timeout 15`) are mandatory on every region-loop call so a down region cannot stall the loop.
+- The `SkipRegions` Make variable exists for permanent exclusions (broken regions, regions the org has intentionally disabled in spirit but not via opt-in status).
+
+## Validation before opening a PR
+
+1. `cfn-lint cfn-local.yml cfn-global.yml` must pass without warnings.
+2. `make -n deploy` must expand cleanly with the parameters you expect.
+3. A live deploy to a sandbox AWS account is strongly recommended for any non-trivial change. The typical command is `aws-vault exec <profile> -- make deploy` with `Profile=""` in the `Makefile`.
+
+## Documentation rule
+
+`README.md` is the user-facing source of truth. `AGENT.md` is the agent-facing source of truth.
+
+**Any change to `cfn-local.yml`, `cfn-global.yml`, or `Makefile` that adds, removes, or modifies a parameter, a detection rule, or a deployment step MUST be reflected in `README.md` in the same PR.** Concretely:
+
+- New EventBridge rule: add an entry to the appropriate foldable list in "What it watches".
+- New parameter: add a row to the relevant Parameters table.
+- New `Makefile` target or changed `deploy` semantics: update the Quick Start section.
+- Changed defaults: update the table and the related prose.
+
+`AGENT.md` (this file) follows the same rule: any change to project conventions, layout, or workflow MUST be reflected here in the same PR.
+
+If a change cannot be fully documented in the same PR, open a follow-up issue explicitly tracking the documentation debt. Documentation drift is a bug.
+
+## Out of scope
+
+The following are deliberate non-goals. Do not add them without a separate discussion with the maintainer:
+
+- A SIEM, a SOAR, a remediation engine. ASSK alerts. It does not act.
+- Per-rule fine-grained tuning UIs. Parameter overrides via the `Makefile` is the deliberate interface.
+- Multi-account orchestration. ASSK deploys per-account; multi-account is a higher-order tool's job.
+- Custom Lambda, EC2, or container infrastructure. Everything must be plain managed AWS primitives (EventBridge, SNS, CloudWatch, KMS).
+
+## Related issues
+
+- `#32`: original suggestions thread that motivated the latest batch of detections and hardening.
+- `#33`: tracker for 17 additional high-signal detection ideas (Persistence, Data exfiltration, Network exposure, SSO, Reconnaissance) that are not yet implemented.

--- a/Makefile
+++ b/Makefile
@@ -11,51 +11,105 @@ help:
 	@echo "	clean - clean temp folders"
 
 ###################### Parameters ######################
-AlarmRecipient ?= "hello@zoph.io"
-Project ?= "aws-security-survival-kit"
-Description ?= "Bare minimum AWS Security alerting and configuration"
-LocalAWSRegion ?= "eu-west-1"
-CTLogGroupName ?= "aws-cloudtrail-logs-567589703415-c7b72250"
-Profile ?= ""
+AlarmRecipient ?= hello@zoph.io
+Project ?= aws-security-survival-kit
+Description ?= Bare minimum AWS Security alerting and configuration
+LocalAWSRegion ?= eu-west-1
+CTLogGroupName ?= aws-cloudtrail-logs-567589703415-c7b72250
+
+# Pass Profile=<name> to use a named AWS CLI profile. Leave empty (default)
+# when credentials come from the environment (e.g. `aws-vault exec`, IAM Role,
+# ECS task role) - in that case the --profile flag is omitted entirely.
+Profile ?=
+PROFILE_FLAG := $(if $(strip $(Profile)),--profile $(Profile),)
+
+# Space-separated list of regions to SKIP during account_level_security.
+# Use this for regions that are currently down, that you do not use, or
+# that consistently 5xx (e.g. me-south-1 has had EC2 control-plane issues).
+# Example: make deploy SkipRegions="me-south-1 ap-east-2"
+SkipRegions ?=
+
+# Per-API-call timeout. Without this, a single unreachable region can stall
+# the hardening loop for several minutes (default AWS CLI socket timeout is
+# 60s per call x 4 calls per region). 10s connect / 15s read fails fast.
+AwsCliTimeouts := --cli-connect-timeout 10 --cli-read-timeout 15
+
+# Optional S3 bucket(s) for CloudFormation template staging.
+# Required once the templates grow past 51,200 bytes (CFN inline limit).
+# Leave empty to attempt inline deploy. If your account has CFN's default
+# managed bucket, it is named cf-templates-<random>-<region> - run
+# `aws s3 ls | grep cf-templates` to find yours, or create one.
+LocalS3Bucket  ?=
+GlobalS3Bucket ?=
+LOCAL_S3_FLAG  := $(if $(strip $(LocalS3Bucket)),--s3-bucket $(LocalS3Bucket) --s3-prefix assk,)
+GLOBAL_S3_FLAG := $(if $(strip $(GlobalS3Bucket)),--s3-bucket $(GlobalS3Bucket) --s3-prefix assk,)
+
+# ---- Optional detections (opt-in, default "false") ----
+EnableS3PolicyDetection ?= "false"
+EnableLambdaDetection ?= "false"
+EnableSSODetection ?= "false"
+EnableNetworkInfrastructureDetection ?= "false"
+EnableIamTrustPolicyDetection ?= "false"
+EnableOrganizationsDetection ?= "false"
+
+# ---- Existing-but-noisy detections (default ON for back-compat; flip to
+# ---- "false" if alert fatigue is a problem in your environment) ----
+EnableGetCallerIdentityDetection ?= "true"
+EnableSecretsBatchGetDetection ?= "true"
+EnableEc2PasswordDataDetection ?= "true"
+
+# ---- Alarm tuning ----
+AccessDeniedThreshold ?= 25
+
+# ---- SNS encryption (optional CMK) ----
+# Set EnableSnsEncryption="true" to create a dedicated KMS CMK for the SNS
+# alerting topics. Cost consideration applies (KMS key + per-API-call charges).
+# TrustedAccountIds is a comma-separated list of AWS account IDs that should be
+# allowed to use the CMK (cross-account publish). Leave empty for single-account.
+EnableSnsEncryption ?= "false"
+TrustedAccountIds ?= ""
 #######################################################
 
+# Hardening across ALL enabled regions. The four ec2 APIs invoked here
+# (enable-ebs-encryption-by-default, enable-image-block-public-access,
+# enable-snapshot-block-public-access, modify-instance-metadata-defaults)
+# are REGION-SCOPED, so applying them only to LocalAWSRegion leaves every
+# other region unprotected. We loop over enabled+default-opted-in regions.
+# S3 Block Public Access is account-scoped and only needs to run once.
 account_level_security:
-# Block S3 Bucket Public Access
 	@echo "==> Enable S3 Block Public Access (Account Level)"
 	@aws s3control put-public-access-block \
 		--public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true \
-		--account-id $(shell aws sts get-caller-identity --query Account --output text)
-	@if [ $$? -eq 0 ]; then echo "✅ S3 Block Public Access Enabled"; fi
+		--account-id $$(aws sts get-caller-identity --query Account --output text ${PROFILE_FLAG}) \
+		${PROFILE_FLAG}
+	@if [ $$? -eq 0 ]; then echo "✅ S3 Block Public Access Enabled (account)"; fi
 
-# Enable EBS Default Encryption
-	@echo "==> Enable EBS Default Encryption (Region Level)"
-	@aws ec2 enable-ebs-encryption-by-default \
-		--region ${LocalAWSRegion}
-	@if [ $$? -eq 0 ]; then echo "✅ EBS Default Encryption Enabled" ; fi
+	@echo "==> Apply region-scoped hardening across ALL enabled regions"
+	@echo "    (SkipRegions='${SkipRegions}', per-call timeouts: connect=10s read=15s)"
+	@SKIP=" ${SkipRegions} "; \
+	for region in $$(aws ec2 describe-regions --all-regions \
+			--filters "Name=opt-in-status,Values=opt-in-not-required,opted-in" \
+			--query 'Regions[].RegionName' --output text ${PROFILE_FLAG}); do \
+		case "$$SKIP" in *" $$region "*) \
+			echo "  --> $$region [SKIPPED via SkipRegions]"; continue;; \
+		esac; \
+		echo "  --> $$region"; \
+		aws ec2 enable-ebs-encryption-by-default --region $$region ${PROFILE_FLAG} ${AwsCliTimeouts} > /dev/null 2>&1 \
+			&& echo "    ✅ EBS default encryption" \
+			|| echo "    ⚠️  EBS default encryption skipped"; \
+		aws ec2 enable-image-block-public-access --image-block-public-access-state block-new-sharing --region $$region ${PROFILE_FLAG} ${AwsCliTimeouts} > /dev/null 2>&1 \
+			&& echo "    ✅ AMI block public sharing" \
+			|| echo "    ⚠️  AMI block public sharing skipped"; \
+		aws ec2 enable-snapshot-block-public-access --state block-new-sharing --region $$region ${PROFILE_FLAG} ${AwsCliTimeouts} > /dev/null 2>&1 \
+			&& echo "    ✅ Snapshot block public sharing" \
+			|| echo "    ⚠️  Snapshot block public sharing skipped"; \
+		aws ec2 modify-instance-metadata-defaults --http-tokens required --http-put-response-hop-limit 2 --region $$region ${PROFILE_FLAG} ${AwsCliTimeouts} > /dev/null 2>&1 \
+			&& echo "    ✅ IMDSv2 default" \
+			|| echo "    ⚠️  IMDSv2 default skipped"; \
+	done
+	@echo "==> Region-scoped hardening complete"
 
-# Enable AMI Block Public Access (New Sharing Only)
-	@echo "==> Enable AMI Block Public Access (Region Level)"
-	@aws ec2 enable-image-block-public-access \
-		--image-block-public-access-state block-new-sharing \
-		--region ${LocalAWSRegion}
-	@if [ $$? -eq 0 ]; then echo "✅ AMI Block Public Access Enabled"; fi
-
-# Enable Snapshot Block Public Access (New Sharing Only)
-	@echo "==> Enable Snapshot Block Public Access (Region Level)"
-	@aws ec2 enable-snapshot-block-public-access \
-		--state block-new-sharing \
-		--region ${LocalAWSRegion}
-	@if [ $$? -eq 0 ]; then echo "✅ Snapshot Block Public Access Enabled"; fi
-
-# Enable Instance Metadata Service Version 2 Default
-	@echo "==> Enable IMDSv2 by Default (Region Level)"
-	@aws ec2 modify-instance-metadata-defaults \
-		--region ${LocalAWSRegion} \
-		--http-tokens required \
-		--http-put-response-hop-limit 2
-	@if [ $$? -eq 0 ]; then echo "✅ IMDSv2 is now set by default"; fi
-
-deploy: #account_level_security
+deploy: account_level_security
 	@echo "==> Deploying Local Stack (${LocalAWSRegion})"
 	@aws cloudformation deploy \
 		--template-file ./cfn-local.yml \
@@ -66,8 +120,26 @@ deploy: #account_level_security
 			Region=${LocalAWSRegion} \
 			AlarmRecipient=${AlarmRecipient} \
 			CTLogGroupName=${CTLogGroupName} \
+			AccessDeniedThreshold=${AccessDeniedThreshold} \
+			EnableS3PolicyDetection=${EnableS3PolicyDetection} \
+			EnableLambdaDetection=${EnableLambdaDetection} \
+			EnableSSODetection=${EnableSSODetection} \
+			EnableNetworkInfrastructureDetection=${EnableNetworkInfrastructureDetection} \
+			EnableGetCallerIdentityDetection=${EnableGetCallerIdentityDetection} \
+			EnableSecretsBatchGetDetection=${EnableSecretsBatchGetDetection} \
+			EnableEc2PasswordDataDetection=${EnableEc2PasswordDataDetection} \
+			EnableSnsEncryption=${EnableSnsEncryption} \
+			TrustedAccountIds=${TrustedAccountIds} \
 		--no-fail-on-empty-changeset \
-		--profile ${Profile}
+		${LOCAL_S3_FLAG} \
+		${PROFILE_FLAG}
+	@echo "==> Enabling termination protection on Local Stack"
+	@aws cloudformation update-termination-protection \
+		--region ${LocalAWSRegion} \
+		--stack-name "${Project}-local" \
+		--enable-termination-protection \
+		${PROFILE_FLAG} > /dev/null
+	@if [ $$? -eq 0 ]; then echo "✅ Termination protection enabled on ${Project}-local"; fi
 
 	@echo "==> Deploying Global Stack (us-east-1)"
 	@aws cloudformation deploy \
@@ -77,13 +149,28 @@ deploy: #account_level_security
 		--parameter-overrides \
 			Project=${Project} \
 			AlarmRecipient=${AlarmRecipient} \
+			EnableIamTrustPolicyDetection=${EnableIamTrustPolicyDetection} \
+			EnableOrganizationsDetection=${EnableOrganizationsDetection} \
+			EnableSnsEncryption=${EnableSnsEncryption} \
+			TrustedAccountIds=${TrustedAccountIds} \
 		--no-fail-on-empty-changeset \
-		--profile ${Profile}
+		${GLOBAL_S3_FLAG} \
+		${PROFILE_FLAG}
+	@echo "==> Enabling termination protection on Global Stack"
+	@aws cloudformation update-termination-protection \
+		--region us-east-1 \
+		--stack-name "${Project}-global" \
+		--enable-termination-protection \
+		${PROFILE_FLAG} > /dev/null
+	@if [ $$? -eq 0 ]; then echo "✅ Termination protection enabled on ${Project}-global"; fi
 
 tear-down:
 	@read -p "Are you sure that you want to destroy stack '${Project}'? [y/N]: " sure && [ $${sure:-N} = 'y' ]
-	aws cloudformation delete-stack --region ${LocalAWSRegion} --stack-name "${Project}-local" --profile ${Profile}
-	aws cloudformation delete-stack --region us-east-1 --stack-name "${Project}-global" --profile ${Profile}
+	@echo "==> Disabling termination protection (required before delete)"
+	-aws cloudformation update-termination-protection --region ${LocalAWSRegion} --stack-name "${Project}-local" --no-enable-termination-protection ${PROFILE_FLAG} > /dev/null
+	-aws cloudformation update-termination-protection --region us-east-1 --stack-name "${Project}-global" --no-enable-termination-protection ${PROFILE_FLAG} > /dev/null
+	aws cloudformation delete-stack --region ${LocalAWSRegion} --stack-name "${Project}-local" ${PROFILE_FLAG}
+	aws cloudformation delete-stack --region us-east-1 --stack-name "${Project}-global" ${PROFILE_FLAG}
 
 clean:
 	@rm -fr temp/

--- a/README.md
+++ b/README.md
@@ -1,22 +1,42 @@
 # 🚑 AWS Security Survival Kit
 
-## :brain: Rationale
+## :brain: Why this kit exists
 
-The AWS Security Survival Kit (ASSK) helps you monitor and get alerts about suspicious activities in your AWS account.
+If you run AWS workloads — solo, in a small team, or as the security person on a small org — you have probably noticed that AWS gives you excellent **logging** (CloudTrail, VPC Flow Logs, Config) but very few **alerts**. The signal lives in your logs; the burden of looking at them is on you.
 
-While [CloudTrail](https://aws.amazon.com/cloudtrail/) is essential for tracking AWS account activities, it doesn't provide automatic alerts. you need to manually check logs across multiple services and the console to spot issues.
+`GuardDuty` covers a narrow slice (threat-intel matching, anomaly detection on a handful of services). It does **not** tell you when:
 
-This kit uses CloudFormation templates to set up proactive security monitoring and alerting. it works alongside GuardDuty to fill the gap of missing built-in alerts.
+- The root account just logged in.
+- Someone disabled CloudTrail, deleted a KMS key, or stopped your GuardDuty detector.
+- A new IAM user was created, or `AdministratorAccess` was just attached to a role.
+- A security group was opened on port 22 to `0.0.0.0/0`.
+- A snapshot or AMI was just shared with another AWS account.
+- A flood of `AccessDenied` errors is happening (a sign of enumeration / a misconfigured workload / a compromised credential probing).
+- Your own monitoring stack just got deleted.
+
+The **AWS Security Survival Kit (ASSK)** is the smallest possible answer to "I want an email in my inbox the moment any of the above happens, without paying for a SIEM." It is two CloudFormation stacks (one regional, one in `us-east-1` for global services) that wire ~25 EventBridge rules and a few CloudWatch metric alarms into an SNS topic that sends you email (or feeds into Slack/Teams via AWS Chatbot).
+
+Design principles:
+
+1. **Free or near-free.** Everything is serverless and pay-per-use. Typical accounts pay cents per month.
+2. **No agents, no extra accounts, no SaaS.** Deploys into the account you want to monitor.
+3. **Actionable signal.** Each alert email is a small structured JSON payload (event name, account, region, who, source IP), not a raw CloudTrail blob — so you can triage from your phone in 5 seconds.
+4. **Secure by default.** `make deploy` first hardens the account (S3 Block Public Access, EBS encryption, public AMI/snapshot blocking, IMDSv2 default) across every enabled region, then deploys the alerting stacks with termination protection.
+5. **Complements, does not replace, GuardDuty.** Both stacks run side by side; ASSK alerts on tampering and on the "boring but high-signal" events GuardDuty does not surface.
+
+This is **not** a replacement for a SIEM, a SOAR, or a full detection engineering practice. It is a survival kit — the bare minimum so that "I'd notice within minutes if something obviously bad happens" is true for your AWS account.
 
 ## ✅ Secure by default
 
-This kit enables several important security configurations in your aws account by default:
+`make deploy` runs `account_level_security` as a prerequisite, which applies the following hardening:
 
-1. Automatic encryption for all ebs volumes (per region)
-2. Account-wide s3 block public access
-3. Prevention of public ami sharing (per region) - [Annoncement](https://aws.amazon.com/about-aws/whats-new/2023/10/ami-block-public-enabled-aws-accounts-no-public-amis/)
-4. Prevention of public snapshot sharing (per region) - [Blogpost](https://aws.amazon.com/blogs/aws/new-block-public-sharing-of-amazon-ebs-snapshots/)
-5. IMDSv2 requirement for new instances (per region) - [Annoncement](https://aws.amazon.com/about-aws/whats-new/2024/03/set-imdsv2-default-new-instance-launches/)
+1. Account-wide S3 Block Public Access (account-scoped, single call)
+2. EBS default encryption — **applied to every enabled region** in the account
+3. Block public AMI sharing — **applied to every enabled region** ([Announcement](https://aws.amazon.com/about-aws/whats-new/2023/10/ami-block-public-enabled-aws-accounts-no-public-amis/))
+4. Block public snapshot sharing — **applied to every enabled region** ([Blog post](https://aws.amazon.com/blogs/aws/new-block-public-sharing-of-amazon-ebs-snapshots/))
+5. IMDSv2 required by default for new EC2 instances — **applied to every enabled region** ([Announcement](https://aws.amazon.com/about-aws/whats-new/2024/03/set-imdsv2-default-new-instance-launches/))
+
+The region loop uses `aws ec2 describe-regions` filtered on `opt-in-status in (opt-in-not-required, opted-in)`, so you do not need to maintain a region list manually. Failures in individual regions (e.g. service-unavailable in a new region) are logged with a warning and do not abort the deploy.
 
 ## 💾 Suspicious Activities
 
@@ -47,20 +67,68 @@ The following suspicious activities are currently supported:
 21. Security Group Admin Ports Exposure (`AuthorizeSecurityGroupIngress` with ports 22/3389 from 0.0.0.0/0)
 22. IAM Roles Anywhere Changes (`CreateProfile`, `CreateTrustAnchor`)
 23. STS Federation Token Creation (`GetFederationToken`)
+24. GuardDuty Tampering (`DeleteDetector`, `UpdateDetector`, `DeletePublishingDestination`, `StopMonitoringMembers`, `CreateFilter` with `ARCHIVE` action)
+25. ASSK Self-Protection (`DeleteStack`, `UpdateTerminationProtection` on stacks matching `${Project}-*`) — see caveat below
+26. Security Group Admin Ports Exposure (IPv6) — `AuthorizeSecurityGroupIngress` with ports 22/3389 from `::/0`
+
+The following detections are **opt-in** (off by default) because they can be noisy or are only meaningful in specific account/region contexts. Enable them via Makefile variables or CFN parameter overrides:
+
+| Detection                                                                                            | Parameter                              | Default | When to enable                                                       |
+| ---------------------------------------------------------------------------------------------------- | -------------------------------------- | ------- | -------------------------------------------------------------------- |
+| S3 bucket policy / ACL / PublicAccessBlock changes                                                   | `EnableS3PolicyDetection`              | `false` | When you want to be alerted on any S3 access-surface change          |
+| Lambda creation / code update / permission grants (uses `prefix` matchers, future-proof)             | `EnableLambdaDetection`                | `false` | When you don't deploy Lambdas frequently from IaC                    |
+| IAM Identity Center (SSO) permission set / account assignment changes                                | `EnableSSODetection`                   | `false` | Only in the **account and region** of the SSO/Identity Center tenant |
+| Network infrastructure changes (VPC peering, routes, IGW)                                            | `EnableNetworkInfrastructureDetection` | `false` | Off by default - very noisy in IaC-driven environments               |
+| IAM `UpdateAssumeRolePolicy` (role trust policy changes)                                             | `EnableIamTrustPolicyDetection`        | `false` | Trust-policy modifications are a common backdoor mechanism           |
+| AWS Organizations tampering (`DetachPolicy`, `DeletePolicy`, `DisablePolicyType`, `LeaveOrganization`, `RemoveAccountFromOrganization`) | `EnableOrganizationsDetection`         | `false` | Only in the **Organizations management (OrgAdmin) account**          |
+
+### Existing detections you may want to turn OFF
+
+For backward compatibility these stay on, but they are **alert-fatigue cannons** in active accounts. Flip the relevant parameter to `"false"` if your inbox is drowning:
+
+| Detection                                                  | Parameter                          | Why it is noisy                                                                 |
+| ---------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------- |
+| `sts:GetCallerIdentity`                                    | `EnableGetCallerIdentityDetection` | Called on every AWS SDK init, every `terraform plan`, every CI step             |
+| `secretsmanager:BatchGetSecretValue`                       | `EnableSecretsBatchGetDetection`   | Called by ECS/EKS/Lambda startup when batch-loading secrets                     |
+| `ec2:GetPasswordData`                                      | `EnableEc2PasswordDataDetection`   | Called by SSM and admin tooling every time a Windows admin password is fetched  |
+
+### Self-protection — what it can and cannot catch
+
+The self-protection rule alerts on `DeleteStack` and `UpdateTerminationProtection` against any stack matching `${Project}-*` (matches both literal stack names and stack ARNs). The rule's `requestParameters.stackName` matcher uses `prefix` + `wildcard` so the ARN form (`arn:...:stack/${Project}-local/uuid`) is also caught.
+
+**Honest caveat**: the rule's SNS target lives in the same stack being deleted. For `UpdateTerminationProtection` the alert reliably fires (nothing is being deleted yet). For `DeleteStack`, EventBridge and SNS are torn down concurrently with the rule trying to fire — delivery is best-effort. For airtight self-protection you need either an SCP `Deny`, a watchdog stack in a separate account, or both.
 
 ## :keyboard: Usage
 
 ### Parameters
 
-- `AlarmRecipient`: Recipient for the alerts (e.g.: hello@zoph.io)
-- `Project`: Name of the Project (e.g.: aws-security-survival-kit)
-- `Description`: Description of the Project (e.g.: Bare minimum ...)
-- `LocalAWSRegion`: Region where your workloads and CloudTrail are located (e.g.: `eu-west-1`)
-- `CTLogGroupName`: Cloudtrail CloudWatch LogGroup name (**Required**)
+Core:
 
-Setup the correct parameters in the `Makefile`, then run the following command:
+- `AlarmRecipient`: Recipient for the alerts (e.g.: `hello@zoph.io`)
+- `Project`: Name of the project / stack-name prefix (e.g.: `aws-security-survival-kit`)
+- `LocalAWSRegion`: Region where the CloudTrail CloudWatch Logs `LogGroup` lives. The metric-filter-based alarms (Access Denied, Failed Console Login, IMDSv1) are evaluated in this region. EventBridge rules in `cfn-local.yml` are deployed here.
+- `CTLogGroupName`: CloudTrail CloudWatch Logs LogGroup name (**Required**)
+
+Tuning:
+
+- `AccessDeniedThreshold` (default `25`): Threshold for the "Unauthorized API Call" alarm. The alarm is evaluated as `Period=3600s, EvaluationPeriods=2, Statistic=Sum`, so it fires when **`AccessDeniedThreshold` or more events occur in each of two consecutive 1-hour windows**. Raised from the original `1` to absorb legitimate `AccessDenied` noise (SCP blocks, eventual-consistency lookups, idempotent re-tries).
+
+Opt-in detections (default `"false"`) and back-compat-on noisy detections: see the tables in the "Suspicious Activities" section above.
+
+Optional SNS encryption at rest:
+
+- `EnableSnsEncryption` (default `"false"`): When `"true"`, both alerting SNS topics are encrypted at rest with a dedicated customer-managed KMS key (CMK). **Cost note**: this creates **two** CMKs (one per stack, regional and us-east-1) — roughly `$2/month` at rest plus per-API-call `GenerateDataKey`/`Decrypt` charges that scale with alert volume. The CMK key policy grants `kms:Decrypt` + `kms:GenerateDataKey*` to `events.amazonaws.com`, `cloudwatch.amazonaws.com`, and `chatbot.amazonaws.com`, so AWS Chatbot integration keeps working when encryption is enabled.
+- `TrustedAccountIds` (default `""`): Comma-separated list of AWS account IDs allowed to use the CMK for cross-account publish. Leave empty for single-account.
+
+Setup the correct values at the top of [Makefile](Makefile), then run:
 
     $ make deploy
+
+`make deploy` first runs `account_level_security` (the region-loop hardening above), then deploys both CloudFormation stacks, then enables CloudFormation stack termination protection on both — so the kit cannot be torn down with a single API call. `make tear-down` disables termination protection first and then deletes both stacks.
+
+### SNS topic policy hardening
+
+The alerting topic's resource policy intentionally does **not** grant `sns:Subscribe` to in-account principals via `Principal: "*"`. A compromised role with `sns:Subscribe` only via topic policy could otherwise add an attacker email/HTTPS endpoint and silently exfiltrate every security alert. Adding additional subscribers still works for principals that hold `sns:Subscribe` via IAM (the normal admin flow).
 
 ### 📫 Notifications
 

--- a/README.md
+++ b/README.md
@@ -1,155 +1,179 @@
 # 🚑 AWS Security Survival Kit
 
-## :brain: Why this kit exists
+The smallest possible AWS account monitoring kit. Two CloudFormation stacks, ~25 EventBridge rules, an SNS topic. You get an email (or Slack / Teams via AWS Chatbot) the moment something interesting happens in your account. Free or near-free, no agents, no extra accounts, no SaaS.
 
-If you run AWS workloads — solo, in a small team, or as the security person on a small org — you have probably noticed that AWS gives you excellent **logging** (CloudTrail, VPC Flow Logs, Config) but very few **alerts**. The signal lives in your logs; the burden of looking at them is on you.
+## Why this exists
 
-`GuardDuty` covers a narrow slice (threat-intel matching, anomaly detection on a handful of services). It does **not** tell you when:
+AWS gives you excellent logging (CloudTrail, VPC Flow Logs, Config) but very few alerts. GuardDuty covers a narrow slice (threat intel, anomaly detection on a few services). It does not tell you when:
 
 - The root account just logged in.
 - Someone disabled CloudTrail, deleted a KMS key, or stopped your GuardDuty detector.
-- A new IAM user was created, or `AdministratorAccess` was just attached to a role.
+- A new IAM user was created, or `AdministratorAccess` was attached to a role.
 - A security group was opened on port 22 to `0.0.0.0/0`.
-- A snapshot or AMI was just shared with another AWS account.
-- A flood of `AccessDenied` errors is happening (a sign of enumeration / a misconfigured workload / a compromised credential probing).
+- A snapshot or AMI was shared with another AWS account.
+- A flood of `AccessDenied` errors is happening (enumeration, misconfigured workload, compromised credential probing).
 - Your own monitoring stack just got deleted.
 
-The **AWS Security Survival Kit (ASSK)** is the smallest possible answer to "I want an email in my inbox the moment any of the above happens, without paying for a SIEM." It is two CloudFormation stacks (one regional, one in `us-east-1` for global services) that wire ~25 EventBridge rules and a few CloudWatch metric alarms into an SNS topic that sends you email (or feeds into Slack/Teams via AWS Chatbot).
+ASSK is the minimum so that *"I would notice within minutes if something obviously bad happens"* is true for your AWS account. It complements GuardDuty. It is not a SIEM, a SOAR, or a full detection engineering practice.
 
-Design principles:
+## Quick start
 
-1. **Free or near-free.** Everything is serverless and pay-per-use. Typical accounts pay cents per month.
-2. **No agents, no extra accounts, no SaaS.** Deploys into the account you want to monitor.
-3. **Actionable signal.** Each alert email is a small structured JSON payload (event name, account, region, who, source IP), not a raw CloudTrail blob — so you can triage from your phone in 5 seconds.
-4. **Secure by default.** `make deploy` first hardens the account (S3 Block Public Access, EBS encryption, public AMI/snapshot blocking, IMDSv2 default) across every enabled region, then deploys the alerting stacks with termination protection.
-5. **Complements, does not replace, GuardDuty.** Both stacks run side by side; ASSK alerts on tampering and on the "boring but high-signal" events GuardDuty does not surface.
+1. Edit the variables at the top of the `Makefile` (`AlarmRecipient`, `Project`, `LocalAWSRegion`, `CTLogGroupName`).
+2. Deploy:
 
-This is **not** a replacement for a SIEM, a SOAR, or a full detection engineering practice. It is a survival kit — the bare minimum so that "I'd notice within minutes if something obviously bad happens" is true for your AWS account.
+```sh
+make deploy
+```
 
-## ✅ Secure by default
+`make deploy` does three things, in order:
 
-`make deploy` runs `account_level_security` as a prerequisite, which applies the following hardening:
+1. Hardens the account (S3 Block Public Access, EBS encryption, public AMI / snapshot block, IMDSv2 default) across every enabled region.
+2. Deploys both CloudFormation stacks (`-local` in your region, `-global` in `us-east-1`).
+3. Enables CloudFormation stack termination protection on both stacks.
 
-1. Account-wide S3 Block Public Access (account-scoped, single call)
-2. EBS default encryption — **applied to every enabled region** in the account
-3. Block public AMI sharing — **applied to every enabled region** ([Announcement](https://aws.amazon.com/about-aws/whats-new/2023/10/ami-block-public-enabled-aws-accounts-no-public-amis/))
-4. Block public snapshot sharing — **applied to every enabled region** ([Blog post](https://aws.amazon.com/blogs/aws/new-block-public-sharing-of-amazon-ebs-snapshots/))
-5. IMDSv2 required by default for new EC2 instances — **applied to every enabled region** ([Announcement](https://aws.amazon.com/about-aws/whats-new/2024/03/set-imdsv2-default-new-instance-launches/))
+`make tear-down` disables termination protection and deletes both stacks.
 
-The region loop uses `aws ec2 describe-regions` filtered on `opt-in-status in (opt-in-not-required, opted-in)`, so you do not need to maintain a region list manually. Failures in individual regions (e.g. service-unavailable in a new region) are logged with a warning and do not abort the deploy.
+## What it watches
 
-## 💾 Suspicious Activities
+<details>
+<summary><b>Always-on detections</b> (CloudWatch alarms and EventBridge rules)</summary>
 
-Using this kit, you will deploy EventBridge (CloudWatch Event) Rules and CloudWatch Metric Filters and Alarms on following suspicious activities. It comes with CloudWatch Dashboards to give you more insights about what is ringing 🔔
+1. Root user activity
+2. CloudTrail tampering (`StopLogging`, `DeleteTrail`, `UpdateTrail`)
+3. AWS Health Dashboard events
+4. IAM user changes (`Create`, `Delete`, `Update`, `CreateAccessKey`, `UpdateLoginProfile`, ...)
+5. IAM admin escalation (`Attach*Policy` with `AdministratorAccess`)
+6. MFA changes (`CreateVirtualMFADevice`, `DeactivateMFADevice`, `DeleteVirtualMFADevice`, ...)
+7. AccessDenied / UnauthorizedOperation burst (alarm, threshold configurable, see Parameters)
+8. Console login failures (alarm)
+9. EBS snapshot exfiltration (`ModifySnapshotAttribute`, `SharedSnapshotCopyInitiated`, `SharedSnapshotVolumeCreated`)
+10. AMI exfiltration (`ModifyImageAttribute`)
+11. `sts:GetCallerIdentity` (flippable, see "may want to turn OFF" below)
+12. IMDSv1 `RunInstances`
+13. CloudShell exfiltration (`GetFileDownloadUrls`)
+14. KMS key tampering (`DisableKey`, `ScheduleKeyDeletion`, `DeleteAlias`, `DisableKeyRotation`)
+15. Security group ingress / egress changes
+16. AWS Config tampering (`StopConfigurationRecorder`, `DeleteConfigurationRecorder`, `DeleteConfigRule`, `DeleteEvaluationResults`)
+17. `ec2:GetPasswordData` (flippable, see "may want to turn OFF" below)
+18. `secretsmanager:BatchGetSecretValue` (flippable, see "may want to turn OFF" below)
+19. Route53 Resolver query-log deletion (`DeleteResolverQueryLogConfig`)
+20. VPC Flow Logs (`DeleteFlowLogs`, `ModifyFlowLogs`)
+21. Security group admin-port exposure IPv4 (22 / 3389 from `0.0.0.0/0`)
+22. Security group admin-port exposure IPv6 (22 / 3389 from `::/0`)
+23. IAM Roles Anywhere (`CreateProfile`, `CreateTrustAnchor`)
+24. STS `GetFederationToken`
+25. GuardDuty tampering (`DeleteDetector`, `UpdateDetector`, `DeletePublishingDestination`, `StopMonitoringMembers`, `CreateFilter` with `ARCHIVE`)
+26. Self-protection (`DeleteStack`, `UpdateTerminationProtection` on `${Project}-*` stacks, see caveat below)
 
-The following suspicious activities are currently supported:
+</details>
 
-1. Root User activities
-2. CloudTrail changes (`StopLogging`, `DeleteTrail`, `UpdateTrail`)
-3. AWS Personal Health Dashboard Events
-4. IAM Users Changes (`Create`, `Delete`, `Update`, `CreateAccessKey`, `UpdateLoginProfile`, etc..)
-5. IAM Suspicious Activities (`Attach*Policy`) with `AdministratorAccess` Managed IAM Policy
-6. MFA Monitoring (`CreateVirtualMFADevice` `DeactivateMFADevice` `DeleteVirtualMFADevice`, etc..)
-7. Unauthorized Operations (`Access Denied`, `UnauthorizedOperation`)
-8. Failed AWS Console login authentication (`ConsoleLoginFailures`)
-9. EBS Snapshots Exfiltration (`ModifySnapshotAttribute`, `SharedSnapshotCopyInitiated` `SharedSnapshotVolumeCreated`)
-10. AMI Exfiltration (`ModifyImageAttribute`)
-11. Who Am I Calls (`GetCallerIdentity`)
-12. IMDSv1 RunInstances (`RunInstances` && `optional` http tokens)
-13. CloudShell Exfiltration (`GetFileDownloadUrls`)
-14. KMS Key Changes (`DisableKey`, `ScheduleKeyDeletion`, `DeleteAlias`, `DisableKeyRotation`)
-15. Security Group Changes (`AuthorizeSecurityGroupIngress`, `RevokeSecurityGroupIngress`, `AuthorizeSecurityGroupEgress`, `RevokeSecurityGroupEgress`)
-16. AWS Config Changes (`StopConfigurationRecorder`, `DeleteConfigurationRecorder`, `DeleteConfigRule`, `DeleteEvaluationResults`)
-17. EC2 Password Data Retrieval (`GetPasswordData`)
-18. Secrets Manager Batch Retrieval (`BatchGetSecretValue`)
-19. Route53 DNS Logging Changes (`DeleteResolverQueryLogConfig`)
-20. VPC Flow Logs Changes (`DeleteFlowLogs`, `ModifyFlowLogs`)
-21. Security Group Admin Ports Exposure (`AuthorizeSecurityGroupIngress` with ports 22/3389 from 0.0.0.0/0)
-22. IAM Roles Anywhere Changes (`CreateProfile`, `CreateTrustAnchor`)
-23. STS Federation Token Creation (`GetFederationToken`)
-24. GuardDuty Tampering (`DeleteDetector`, `UpdateDetector`, `DeletePublishingDestination`, `StopMonitoringMembers`, `CreateFilter` with `ARCHIVE` action)
-25. ASSK Self-Protection (`DeleteStack`, `UpdateTerminationProtection` on stacks matching `${Project}-*`) — see caveat below
-26. Security Group Admin Ports Exposure (IPv6) — `AuthorizeSecurityGroupIngress` with ports 22/3389 from `::/0`
+<details>
+<summary><b>Opt-in detections</b> (default off)</summary>
 
-The following detections are **opt-in** (off by default) because they can be noisy or are only meaningful in specific account/region contexts. Enable them via Makefile variables or CFN parameter overrides:
+Off by default because they are noisy in IaC-heavy environments or only meaningful in specific account / region contexts.
 
-| Detection                                                                                            | Parameter                              | Default | When to enable                                                       |
-| ---------------------------------------------------------------------------------------------------- | -------------------------------------- | ------- | -------------------------------------------------------------------- |
-| S3 bucket policy / ACL / PublicAccessBlock changes                                                   | `EnableS3PolicyDetection`              | `false` | When you want to be alerted on any S3 access-surface change          |
-| Lambda creation / code update / permission grants (uses `prefix` matchers, future-proof)             | `EnableLambdaDetection`                | `false` | When you don't deploy Lambdas frequently from IaC                    |
-| IAM Identity Center (SSO) permission set / account assignment changes                                | `EnableSSODetection`                   | `false` | Only in the **account and region** of the SSO/Identity Center tenant |
-| Network infrastructure changes (VPC peering, routes, IGW)                                            | `EnableNetworkInfrastructureDetection` | `false` | Off by default - very noisy in IaC-driven environments               |
-| IAM `UpdateAssumeRolePolicy` (role trust policy changes)                                             | `EnableIamTrustPolicyDetection`        | `false` | Trust-policy modifications are a common backdoor mechanism           |
-| AWS Organizations tampering (`DetachPolicy`, `DeletePolicy`, `DisablePolicyType`, `LeaveOrganization`, `RemoveAccountFromOrganization`) | `EnableOrganizationsDetection`         | `false` | Only in the **Organizations management (OrgAdmin) account**          |
+| Detection | Parameter | Enable when |
+| --- | --- | --- |
+| S3 bucket policy / ACL / `PublicAccessBlock` changes | `EnableS3PolicyDetection` | You want to be alerted on any S3 access-surface change. |
+| Lambda creation / code update / permission grants | `EnableLambdaDetection` | You do not deploy Lambdas frequently from IaC. |
+| IAM Identity Center (SSO) permission sets and account assignments | `EnableSSODetection` | Only in the account and region of your SSO tenant. |
+| VPC peering, routes, IGW | `EnableNetworkInfrastructureDetection` | You do not modify network infrastructure often. |
+| IAM `UpdateAssumeRolePolicy` (trust policy changes) | `EnableIamTrustPolicyDetection` | You want to catch a common backdoor mechanism. |
+| AWS Organizations tampering (`DetachPolicy`, `DeletePolicy`, `DisablePolicyType`, `LeaveOrganization`, `RemoveAccountFromOrganization`) | `EnableOrganizationsDetection` | Only in the Organizations management account. |
 
-### Existing detections you may want to turn OFF
+</details>
 
-For backward compatibility these stay on, but they are **alert-fatigue cannons** in active accounts. Flip the relevant parameter to `"false"` if your inbox is drowning:
+<details>
+<summary><b>Existing detections you may want to turn OFF</b></summary>
 
-| Detection                                                  | Parameter                          | Why it is noisy                                                                 |
-| ---------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------- |
-| `sts:GetCallerIdentity`                                    | `EnableGetCallerIdentityDetection` | Called on every AWS SDK init, every `terraform plan`, every CI step             |
-| `secretsmanager:BatchGetSecretValue`                       | `EnableSecretsBatchGetDetection`   | Called by ECS/EKS/Lambda startup when batch-loading secrets                     |
-| `ec2:GetPasswordData`                                      | `EnableEc2PasswordDataDetection`   | Called by SSM and admin tooling every time a Windows admin password is fetched  |
+For backward compatibility these stay on, but they are alert-fatigue cannons in active accounts. Flip the parameter to `"false"` if your inbox is drowning.
 
-### Self-protection — what it can and cannot catch
+| Detection | Parameter | Why it is noisy |
+| --- | --- | --- |
+| `sts:GetCallerIdentity` | `EnableGetCallerIdentityDetection` | Called on every AWS SDK init, every `terraform plan`, every CI step. |
+| `secretsmanager:BatchGetSecretValue` | `EnableSecretsBatchGetDetection` | Called by ECS / EKS / Lambda when batch-loading secrets at startup. |
+| `ec2:GetPasswordData` | `EnableEc2PasswordDataDetection` | Called by SSM and admin tooling on every Windows admin password fetch. |
 
-The self-protection rule alerts on `DeleteStack` and `UpdateTerminationProtection` against any stack matching `${Project}-*` (matches both literal stack names and stack ARNs). The rule's `requestParameters.stackName` matcher uses `prefix` + `wildcard` so the ARN form (`arn:...:stack/${Project}-local/uuid`) is also caught.
+</details>
 
-**Honest caveat**: the rule's SNS target lives in the same stack being deleted. For `UpdateTerminationProtection` the alert reliably fires (nothing is being deleted yet). For `DeleteStack`, EventBridge and SNS are torn down concurrently with the rule trying to fire — delivery is best-effort. For airtight self-protection you need either an SCP `Deny`, a watchdog stack in a separate account, or both.
+<details>
+<summary><b>Account-level hardening applied by <code>make deploy</code></b></summary>
 
-## :keyboard: Usage
+1. S3 Block Public Access (account-scoped, single call).
+2. EBS default encryption, in every enabled region.
+3. Block public AMI sharing, in every enabled region. ([announcement](https://aws.amazon.com/about-aws/whats-new/2023/10/ami-block-public-enabled-aws-accounts-no-public-amis/))
+4. Block public snapshot sharing, in every enabled region. ([blog post](https://aws.amazon.com/blogs/aws/new-block-public-sharing-of-amazon-ebs-snapshots/))
+5. IMDSv2 required by default for new EC2 instances, in every enabled region. ([announcement](https://aws.amazon.com/about-aws/whats-new/2024/03/set-imdsv2-default-new-instance-launches/))
 
-### Parameters
+The region loop uses `aws ec2 describe-regions` with `opt-in-status in (opt-in-not-required, opted-in)`, so no manual region list is needed. Per-call CLI timeouts (`--cli-connect-timeout 10 --cli-read-timeout 15`) prevent a slow region from stalling the loop. Use `SkipRegions="us-west-1 me-south-1"` in the `Makefile` to permanently skip a region.
 
-Core:
+</details>
 
-- `AlarmRecipient`: Recipient for the alerts (e.g.: `hello@zoph.io`)
-- `Project`: Name of the project / stack-name prefix (e.g.: `aws-security-survival-kit`)
-- `LocalAWSRegion`: Region where the CloudTrail CloudWatch Logs `LogGroup` lives. The metric-filter-based alarms (Access Denied, Failed Console Login, IMDSv1) are evaluated in this region. EventBridge rules in `cfn-local.yml` are deployed here.
-- `CTLogGroupName`: CloudTrail CloudWatch Logs LogGroup name (**Required**)
+## Parameters
 
-Tuning:
+<details>
+<summary><b>Core</b></summary>
 
-- `AccessDeniedThreshold` (default `25`): Threshold for the "Unauthorized API Call" alarm. The alarm is evaluated as `Period=3600s, EvaluationPeriods=2, Statistic=Sum`, so it fires when **`AccessDeniedThreshold` or more events occur in each of two consecutive 1-hour windows**. Raised from the original `1` to absorb legitimate `AccessDenied` noise (SCP blocks, eventual-consistency lookups, idempotent re-tries).
+| Parameter | Description |
+| --- | --- |
+| `AlarmRecipient` | Email address that receives alerts. |
+| `Project` | Stack-name prefix (also matched by the self-protection rule). Default `aws-security-survival-kit`. |
+| `LocalAWSRegion` | Region where the CloudTrail CloudWatch Logs `LogGroup` lives. Metric-filter alarms (AccessDenied, Failed Console Login, IMDSv1) are evaluated here. EventBridge rules in `cfn-local.yml` are deployed here. |
+| `CTLogGroupName` | CloudTrail CloudWatch Logs `LogGroup` name. Required. |
 
-Opt-in detections (default `"false"`) and back-compat-on noisy detections: see the tables in the "Suspicious Activities" section above.
+</details>
 
-Optional SNS encryption at rest:
+<details>
+<summary><b>Tuning</b></summary>
 
-- `EnableSnsEncryption` (default `"false"`): When `"true"`, both alerting SNS topics are encrypted at rest with a dedicated customer-managed KMS key (CMK). **Cost note**: this creates **two** CMKs (one per stack, regional and us-east-1) — roughly `$2/month` at rest plus per-API-call `GenerateDataKey`/`Decrypt` charges that scale with alert volume. The CMK key policy grants `kms:Decrypt` + `kms:GenerateDataKey*` to `events.amazonaws.com`, `cloudwatch.amazonaws.com`, and `chatbot.amazonaws.com`, so AWS Chatbot integration keeps working when encryption is enabled.
-- `TrustedAccountIds` (default `""`): Comma-separated list of AWS account IDs allowed to use the CMK for cross-account publish. Leave empty for single-account.
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `AccessDeniedThreshold` | `25` | Threshold for the AccessDenied alarm. Evaluated as `Period=3600s, EvaluationPeriods=2, Statistic=Sum`, so it fires when this many events or more occur in each of two consecutive 1-hour windows. Raised from the original `1` to absorb legitimate noise (SCP blocks, eventual-consistency lookups, idempotent retries). |
 
-Setup the correct values at the top of [Makefile](Makefile), then run:
+</details>
 
-    $ make deploy
+<details>
+<summary><b>Optional SNS encryption at rest</b></summary>
 
-`make deploy` first runs `account_level_security` (the region-loop hardening above), then deploys both CloudFormation stacks, then enables CloudFormation stack termination protection on both — so the kit cannot be torn down with a single API call. `make tear-down` disables termination protection first and then deletes both stacks.
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `EnableSnsEncryption` | `"false"` | When `"true"`, both SNS topics are encrypted at rest with a dedicated customer-managed KMS key (CMK). |
+| `TrustedAccountIds` | `""` | Comma-separated list of AWS account IDs allowed to use the CMK for cross-account publish. Leave empty for single-account. |
 
-### SNS topic policy hardening
+**Cost note**: enabling encryption creates two CMKs (one per stack, regional and `us-east-1`). Expect roughly `$2/month` at rest plus per-call `GenerateDataKey` / `Decrypt` charges that scale with alert volume. The CMK key policy grants `kms:Decrypt` and `kms:GenerateDataKey*` to `events.amazonaws.com`, `cloudwatch.amazonaws.com`, and `chatbot.amazonaws.com`, so AWS Chatbot integration keeps working when encryption is enabled.
 
-The alerting topic's resource policy intentionally does **not** grant `sns:Subscribe` to in-account principals via `Principal: "*"`. A compromised role with `sns:Subscribe` only via topic policy could otherwise add an attacker email/HTTPS endpoint and silently exfiltrate every security alert. Adding additional subscribers still works for principals that hold `sns:Subscribe` via IAM (the normal admin flow).
+</details>
 
-### 📫 Notifications
+## Self-protection caveat
 
-> You will receive alerts by emails sent by SNS Topic
+The self-protection rule alerts on `DeleteStack` and `UpdateTerminationProtection` against any stack matching `${Project}-*` (matches both literal stack names and ARNs via `prefix` + `wildcard`).
+
+`UpdateTerminationProtection` reliably fires (nothing is being deleted yet). `DeleteStack` is best-effort: the rule's SNS target lives in the same stack being deleted, so EventBridge and SNS are torn down concurrently with the rule trying to fire. For airtight self-protection use an SCP `Deny`, a watchdog stack in a separate account, or both.
+
+## SNS topic policy
+
+The alerting topic's resource policy intentionally does not grant `sns:Subscribe` to in-account principals via `Principal: "*"`. A compromised role with `sns:Subscribe` only via topic policy could otherwise add an attacker email / HTTPS endpoint and silently exfiltrate every security alert. Subscribing still works for principals that hold `sns:Subscribe` via IAM (the normal admin flow).
+
+## Notifications
+
+Alerts are delivered by email through the SNS topic.
 
 ![Email Notification](./assets/notification.png)
 
-### :robot: ChatOps
+## ChatOps
 
-Setup [AWS Chatbot](https://aws.amazon.com/chatbot/) for best experience to get notified directly on Slack.
+Set up [AWS Chatbot](https://aws.amazon.com/chatbot/) to get notified directly on Slack or Microsoft Teams.
 
-### 📈 Dashboards
+## Dashboards
 
-ASSK comes with two CloudWatch Dashboards (Local and Global) to bring better visibility on suspicious activities on your AWS Account.
+ASSK ships two CloudWatch dashboards (Local and Global) for at-a-glance visibility on suspicious activity.
 
-## :man_technologist: Credits
+## Credits
 
-- 🏴‍☠️ AWS Security Boutique: [zoph.io](https://zoph.io)
-- 🦋 BlueSky: [@zoph](https://bsky.app/zoph.me)
-- 🐦 X: [@zoph](https://x.com/zoph)
+- AWS security boutique: [zoph.io](https://zoph.io)
+- BlueSky: [@zoph](https://bsky.app/zoph.me)
+- X: [@zoph](https://x.com/zoph)
 
-## 🌧️ Other Initiatives
+## Other initiatives
 
-- [Microsoft Azure](https://github.com/O3-Cyber/azure-security-survival-kit) from folks @[O3 Cyber](https://www.o3c.no/)
+- [Azure Security Survival Kit](https://github.com/O3-Cyber/azure-security-survival-kit) by [O3 Cyber](https://www.o3c.no/).

--- a/cfn-global.yml
+++ b/cfn-global.yml
@@ -12,7 +12,34 @@ Parameters:
   Project:
     Type: String
     Description: Project Name
+  EnableIamTrustPolicyDetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: Enable EventBridge rule for IAM UpdateAssumeRolePolicy. Off by default - can be noisy in environments where trust policies are managed by IaC.
+  EnableOrganizationsDetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: Enable EventBridge rule for AWS Organizations tampering (DetachPolicy, DeletePolicy, LeaveOrganization). Only enable in the Organizations management (OrgAdmin) account.
+  EnableSnsEncryption:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: Enable SNS topic encryption at rest using a dedicated customer-managed KMS key (CMK). When true, a CMK is created and used for the alerting topic. Cost consideration applies (KMS key + per-API-call charges).
+  TrustedAccountIds:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: Optional list of AWS account IDs that should be allowed to use the dedicated SNS KMS CMK (cross-account publish). Only relevant when EnableSnsEncryption=true. Leave empty to restrict to this account only.
 ###############################################################################
+
+###########################################################
+Conditions:
+  ###########################################################
+  IamTrustPolicyDetectionEnabled: !Equals [!Ref EnableIamTrustPolicyDetection, "true"]
+  OrganizationsDetectionEnabled: !Equals [!Ref EnableOrganizationsDetection, "true"]
+  SnsEncryptionEnabled: !Equals [!Ref EnableSnsEncryption, "true"]
+  HasTrustedAccountIds: !Not [!Equals [!Join ["", !Ref TrustedAccountIds], ""]]
 
 ###########################################################
 Resources:
@@ -294,12 +321,220 @@ Resources:
             policyArn:
               - "arn:aws:iam::aws:policy/AdministratorAccess"
 
+  EventRuleIamTrustPolicyChanges:
+    Type: "AWS::Events::Rule"
+    Condition: IamTrustPolicyDetectionEnabled
+    Properties:
+      Name: !Sub "${Project}-detect-iam-trust-policy-changes"
+      Description: !Sub "[${Project}] Monitor IAM UpdateAssumeRolePolicy (trust policy changes, opt-in)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              RoleName: "$.detail.requestParameters.roleName"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "👤 RoleName": <RoleName>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "iam.amazonaws.com"
+          eventName:
+            - "UpdateAssumeRolePolicy"
+
+  EventRuleOrganizationsChanges:
+    Type: "AWS::Events::Rule"
+    Condition: OrganizationsDetectionEnabled
+    Properties:
+      Name: !Sub "${Project}-detect-organizations-changes"
+      Description: !Sub "[${Project}] Monitor AWS Organizations tampering (DetachPolicy, DeletePolicy, LeaveOrganization) - opt-in, OrgAdmin account only"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              PolicyId: "$.detail.requestParameters.policyId"
+              TargetId: "$.detail.requestParameters.targetId"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "📜 PolicyId": <PolicyId>,
+                "🎯 TargetId": <TargetId>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "organizations.amazonaws.com"
+          eventName:
+            - "DetachPolicy"
+            - "DeletePolicy"
+            - "DisablePolicyType"
+            - "LeaveOrganization"
+            - "RemoveAccountFromOrganization"
+
+  EventRuleSelfProtection:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Sub "${Project}-detect-self-stack-tampering-global"
+      Description: !Sub "[${Project}] Detect tampering with ASSK CloudFormation stacks (DeleteStack, UpdateTerminationProtection) - global stack"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              StackName: "$.detail.requestParameters.stackName"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "📦 StackName": <StackName>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "cloudformation.amazonaws.com"
+          eventName:
+            - "DeleteStack"
+            - "UpdateTerminationProtection"
+          # CloudTrail records requestParameters.stackName as either the literal
+          # stack name OR a full ARN, depending on how the caller invoked the API.
+          # Match both forms via prefix + wildcard.
+          requestParameters:
+            stackName:
+              - prefix: !Sub "${Project}-"
+              - wildcard: !Sub "*:stack/${Project}-*"
+
+  SnsCmk:
+    Type: "AWS::KMS::Key"
+    Condition: SnsEncryptionEnabled
+    # Explicit Delete to honor `make tear-down`. KMS will still apply its standard
+    # 7-30 day scheduled-deletion window, so accidental deletion remains recoverable.
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      Description: !Sub "[${Project}] CMK for SNS alerting topic encryption (global stack)"
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "EnableIAMUserPermissions"
+            Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: "AllowEventBridgeAndCloudWatchPublish"
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "events.amazonaws.com"
+                - "cloudwatch.amazonaws.com"
+            Action:
+              - "kms:GenerateDataKey*"
+              - "kms:Decrypt"
+            Resource: "*"
+          - Sid: "AllowChatbotDecrypt"
+            # AWS Chatbot needs kms:Decrypt to deliver encrypted SNS messages
+            # to Slack/Teams. Without this, enabling SNS encryption silently
+            # breaks Chatbot notifications.
+            Effect: "Allow"
+            Principal:
+              Service: "chatbot.amazonaws.com"
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey*"
+            Resource: "*"
+          - !If
+            - HasTrustedAccountIds
+            - Sid: "AllowTrustedAccountsPublish"
+              Effect: "Allow"
+              Principal:
+                AWS: !Ref TrustedAccountIds
+              Action:
+                - "kms:GenerateDataKey*"
+                - "kms:Decrypt"
+              Resource: "*"
+            - !Ref "AWS::NoValue"
+      Tags:
+        - Key: "Project"
+          Value: !Ref Project
+
+  SnsCmkAlias:
+    Type: "AWS::KMS::Alias"
+    Condition: SnsEncryptionEnabled
+    Properties:
+      AliasName: !Sub "alias/${Project}-sns-global"
+      TargetKeyId: !Ref SnsCmk
+
   CtAlertingTopic:
     # https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
     Type: "AWS::SNS::Topic"
     Properties:
       DisplayName: !Sub "[${AWS::AccountId}] Security Alarm"
       TopicName: !Sub "${Project}-alarm-topic-${AWS::Region}-global"
+      KmsMasterKeyId: !If
+        - SnsEncryptionEnabled
+        - !Ref SnsCmk
+        - !Ref "AWS::NoValue"
       Subscription:
         - Protocol: email
           Endpoint: !Ref AlarmRecipient
@@ -312,17 +547,20 @@ Resources:
     Properties:
       PolicyDocument:
         Statement:
+          # Read + publish only for in-account principals.
+          # We intentionally do NOT grant sns:Subscribe via the topic policy:
+          # a compromised in-account principal could otherwise add an attacker
+          # email/HTTPS subscriber and silently exfiltrate every security alert.
+          # Subscribing additional recipients still works via IAM-granted
+          # sns:Subscribe (the legitimate admin flow).
+          # Destructive actions (DeleteTopic, SetTopicAttributes, AddPermission,
+          # RemovePermission) are likewise NOT granted here - they require IAM.
           - Sid: "__default_statement_ID"
             Effect: "Allow"
             Principal:
               AWS: "*"
             Action:
               - "sns:GetTopicAttributes"
-              - "sns:SetTopicAttributes"
-              - "sns:AddPermission"
-              - "sns:RemovePermission"
-              - "sns:DeleteTopic"
-              - "sns:Subscribe"
               - "sns:ListSubscriptionsByTopic"
               - "sns:Publish"
               - "sns:Receive"

--- a/cfn-local.yml
+++ b/cfn-local.yml
@@ -18,8 +18,70 @@ Parameters:
   Region:
     Type: String
     Description: AWS Region
+  AccessDeniedThreshold:
+    Type: Number
+    Default: 25
+    MinValue: 1
+    Description: Threshold (per evaluation period) for the Unauthorized API Call alarm. Raised from the original value of 1 to reduce alert fatigue from legitimate AccessDenied noise (SCPs, eventual consistency, etc.).
+  EnableS3PolicyDetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: Enable EventBridge rule for S3 bucket policy/ACL/PublicAccessBlock changes (PutBucketPolicy, DeleteBucketPolicy, PutBucketAcl, PutBucketPublicAccessBlock). Off by default - can be noisy in active environments.
+  EnableLambdaDetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: Enable EventBridge rule for Lambda function creation, code updates, and permission grants. Off by default - can be noisy in environments deploying Lambdas frequently.
+  EnableSSODetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: Enable EventBridge rule for IAM Identity Center (SSO) permission set / account assignment changes. Off by default - only enable in the account and region of the SSO/Identity Center tenant.
+  EnableNetworkInfrastructureDetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: Enable EventBridge rule for VPC peering, route table, and Internet Gateway changes. Off by default - extremely noisy in IaC-driven environments (Terraform/CDK route updates fire continuously).
+  EnableGetCallerIdentityDetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "true"
+    Description: Enable EventBridge rule for sts:GetCallerIdentity calls. On by default for backward compatibility; STRONGLY consider disabling - this API is called by every AWS SDK init, every Terraform plan, etc. and dominates alert volume.
+  EnableSecretsBatchGetDetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "true"
+    Description: Enable EventBridge rule for SecretsManager BatchGetSecretValue calls. On by default for backward compatibility; consider disabling if you have ECS/Lambda/EKS workloads that legitimately batch-load secrets at startup.
+  EnableEc2PasswordDataDetection:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "true"
+    Description: Enable EventBridge rule for ec2:GetPasswordData calls. On by default for backward compatibility; consider disabling in Windows fleets where SSM/admin tools call this routinely.
+  EnableSnsEncryption:
+    Type: String
+    AllowedValues: ["true", "false"]
+    Default: "false"
+    Description: Enable SNS topic encryption at rest using a dedicated customer-managed KMS key (CMK). When true, a CMK is created and used for the alerting topic. Cost consideration applies (KMS key + per-API-call charges).
+  TrustedAccountIds:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: Optional list of AWS account IDs that should be allowed to use the dedicated SNS KMS CMK (cross-account publish). Only relevant when EnableSnsEncryption=true. Leave empty to restrict to this account only.
 
 ###############################################################################
+
+###########################################################
+Conditions:
+  ###########################################################
+  S3PolicyDetectionEnabled: !Equals [!Ref EnableS3PolicyDetection, "true"]
+  LambdaDetectionEnabled: !Equals [!Ref EnableLambdaDetection, "true"]
+  SSODetectionEnabled: !Equals [!Ref EnableSSODetection, "true"]
+  NetworkInfrastructureDetectionEnabled: !Equals [!Ref EnableNetworkInfrastructureDetection, "true"]
+  GetCallerIdentityDetectionEnabled: !Equals [!Ref EnableGetCallerIdentityDetection, "true"]
+  SecretsBatchGetDetectionEnabled: !Equals [!Ref EnableSecretsBatchGetDetection, "true"]
+  Ec2PasswordDataDetectionEnabled: !Equals [!Ref EnableEc2PasswordDataDetection, "true"]
+  SnsEncryptionEnabled: !Equals [!Ref EnableSnsEncryption, "true"]
+  HasTrustedAccountIds: !Not [!Equals [!Join ["", !Ref TrustedAccountIds], ""]]
 
 ###########################################################
 Resources:
@@ -223,6 +285,7 @@ Resources:
 
   EventRuleStsWhoAmI:
     Type: "AWS::Events::Rule"
+    Condition: GetCallerIdentityDetectionEnabled
     Properties:
       Name: !Sub "${Project}-detect-sts-whoami"
       Description: !Sub "[${Project}] Detect STS get-caller-identity"
@@ -327,14 +390,14 @@ Resources:
       AlarmActions:
         - !Ref CtAlertingTopic
       AlarmDescription: >
-        Alarm on Unauthorized API Call
+        Alarm on Unauthorized API Call - threshold configurable via AccessDeniedThreshold parameter (default 25 to reduce noise from legitimate AccessDenied events such as SCP blocks and eventual consistency).
       ComparisonOperator: GreaterThanOrEqualToThreshold
       EvaluationPeriods: 2
       MetricName: "UnauthorizedAttemptCount"
       Namespace: "CloudTrailMetrics"
       Period: 3600
       Statistic: Sum
-      Threshold: 1
+      Threshold: !Ref AccessDeniedThreshold
       TreatMissingData: "notBreaching"
 
   AlarmConsoleFailedAuth:
@@ -489,6 +552,27 @@ Resources:
         - Arn:
             Ref: CtAlertingTopic
           Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>
+              }
       EventPattern:
         detail-type:
           - "AWS API Call via CloudTrail"
@@ -511,6 +595,29 @@ Resources:
         - Arn:
             Ref: CtAlertingTopic
           Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              GroupId: "$.detail.requestParameters.groupId"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🛡️ GroupId": <GroupId>
+              }
       EventPattern:
         detail-type:
           - "AWS API Call via CloudTrail"
@@ -525,6 +632,7 @@ Resources:
 
   EventRuleEC2PasswordData:
     Type: "AWS::Events::Rule"
+    Condition: Ec2PasswordDataDetectionEnabled
     Properties:
       Name: !Sub "${Project}-detect-ec2-password-data"
       Description: !Sub "[${Project}] Monitor EC2 GetPasswordData calls"
@@ -567,6 +675,7 @@ Resources:
 
   EventRuleSecretsManagerBatchGet:
     Type: "AWS::Events::Rule"
+    Condition: SecretsBatchGetDetectionEnabled
     Properties:
       Name: !Sub "${Project}-detect-secretsmanager-batch-get"
       Description: !Sub "[${Project}] Monitor SecretsManager BatchGetSecretValue calls"
@@ -649,11 +758,11 @@ Resources:
           eventName:
             - "DeleteResolverQueryLogConfig"
 
-  EventRuleSecurityGroupOpenAdminPorts:
+  EventRuleSecurityGroupOpenAdminPortsIpv4:
     Type: "AWS::Events::Rule"
     Properties:
-      Name: !Sub "${Project}-detect-sg-open-admin-ports"
-      Description: !Sub "[${Project}] Monitor security group changes that open administrative ports to the internet"
+      Name: !Sub "${Project}-detect-sg-open-admin-ports-ipv4"
+      Description: !Sub "[${Project}] Monitor SG ingress opening admin ports (22/3389) to the internet via IPv4 (0.0.0.0/0)"
       State: "ENABLED"
       Targets:
         - Arn:
@@ -685,7 +794,7 @@ Resources:
                 "👨‍🏭 EventBlame": <EventBlame>,
                 "📃 EventBlameDetails": <EventBlameDetails>,
                 "🛡️ GroupId": <GroupId>,
-                "🔢 CidrIp": <CidrIp>,
+                "🔢 CidrIp (IPv4)": <CidrIp>,
                 "🔌 FromPort": <FromPort>,
                 "🔌 ToPort": <ToPort>,
                 "🔄 Protocol": <IpProtocol>
@@ -701,7 +810,62 @@ Resources:
           requestParameters:
             cidrIp:
               - "0.0.0.0/0"
-              - "*.*.*.*/*"
+            fromPort:
+              - 22
+              - 3389
+
+  EventRuleSecurityGroupOpenAdminPortsIpv6:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Sub "${Project}-detect-sg-open-admin-ports-ipv6"
+      Description: !Sub "[${Project}] Monitor SG ingress opening admin ports (22/3389) to the internet via IPv6 (::/0)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              GroupId: "$.detail.requestParameters.groupId"
+              CidrIpv6: "$.detail.requestParameters.cidrIpv6"
+              FromPort: "$.detail.requestParameters.fromPort"
+              ToPort: "$.detail.requestParameters.toPort"
+              IpProtocol: "$.detail.requestParameters.ipProtocol"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🛡️ GroupId": <GroupId>,
+                "🔢 CidrIp (IPv6)": <CidrIpv6>,
+                "🔌 FromPort": <FromPort>,
+                "🔌 ToPort": <ToPort>,
+                "🔄 Protocol": <IpProtocol>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "ec2.amazonaws.com"
+          eventName:
+            - "AuthorizeSecurityGroupIngress"
+          requestParameters:
+            cidrIpv6:
+              - "::/0"
             fromPort:
               - 22
               - 3389
@@ -731,17 +895,17 @@ Resources:
               TrustAnchorSource: "$.detail.requestParameters.source.sourceData.x509CertificateData"
             InputTemplate: |
               {
-                "EventId": <EventId>,
-                "EventTime": <EventTime>,
-                "EventName": <EventName>,
-                "EventAccountId": <EventAccountId>,
-                "EventSourceIp": <EventSourceIp>,
-                "EventRegion": <EventRegion>,
-                "EventBlame": <EventBlame>,
-                "EventBlameDetails": <EventBlameDetails>,
-                "ProfileName": <ProfileName>,
-                "TrustAnchorName": <TrustAnchorName>,
-                "TrustAnchorSource": <TrustAnchorSource>
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🪪 ProfileName": <ProfileName>,
+                "⚓ TrustAnchorName": <TrustAnchorName>,
+                "📜 TrustAnchorSource": <TrustAnchorSource>
               }
       EventPattern:
         detail-type:
@@ -797,12 +961,431 @@ Resources:
           eventName:
             - "GetFederationToken"
 
+  EventRuleGuardDutyTampering:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Sub "${Project}-detect-guardduty-tampering"
+      Description: !Sub "[${Project}] Monitor GuardDuty tampering (detector/destination deletion or update)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              DetectorId: "$.detail.requestParameters.detectorId"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🛡️ DetectorId": <DetectorId>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "guardduty.amazonaws.com"
+          eventName:
+            - "DeleteDetector"
+            - "UpdateDetector"
+            - "DeletePublishingDestination"
+            - "StopMonitoringMembers"
+
+  EventRuleGuardDutyFilterArchive:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Sub "${Project}-detect-guardduty-filter-archive"
+      Description: !Sub "[${Project}] Monitor GuardDuty CreateFilter with ARCHIVE action (finding suppression)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              FilterName: "$.detail.requestParameters.name"
+              FilterAction: "$.detail.requestParameters.action"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🪪 FilterName": <FilterName>,
+                "🎬 FilterAction": <FilterAction>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "guardduty.amazonaws.com"
+          eventName:
+            - "CreateFilter"
+          requestParameters:
+            action:
+              - "ARCHIVE"
+
+  EventRuleNetworkInfrastructureChanges:
+    Type: "AWS::Events::Rule"
+    Condition: NetworkInfrastructureDetectionEnabled
+    Properties:
+      Name: !Sub "${Project}-detect-network-infra-changes"
+      Description: !Sub "[${Project}] Monitor network infrastructure changes (VPC peering, route tables, internet gateway)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              VpcId: "$.detail.requestParameters.vpcId"
+              RouteTableId: "$.detail.requestParameters.routeTableId"
+              InternetGatewayId: "$.detail.requestParameters.internetGatewayId"
+              DestinationCidrBlock: "$.detail.requestParameters.destinationCidrBlock"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🕸️ VpcId": <VpcId>,
+                "🛣️ RouteTableId": <RouteTableId>,
+                "🌉 InternetGatewayId": <InternetGatewayId>,
+                "🎯 DestinationCidrBlock": <DestinationCidrBlock>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "ec2.amazonaws.com"
+          eventName:
+            - "CreateVpcPeeringConnection"
+            - "AcceptVpcPeeringConnection"
+            - "DeleteVpcPeeringConnection"
+            - "CreateRoute"
+            - "ReplaceRoute"
+            - "DeleteRoute"
+            - "CreateInternetGateway"
+            - "AttachInternetGateway"
+            - "DetachInternetGateway"
+
+  EventRuleS3BucketPolicyChanges:
+    Type: "AWS::Events::Rule"
+    Condition: S3PolicyDetectionEnabled
+    Properties:
+      Name: !Sub "${Project}-detect-s3-bucket-policy-changes"
+      Description: !Sub "[${Project}] Monitor S3 bucket policy, ACL, and PublicAccessBlock changes (opt-in)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              BucketName: "$.detail.requestParameters.bucketName"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🪣 BucketName": <BucketName>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "s3.amazonaws.com"
+          eventName:
+            - "PutBucketPolicy"
+            - "DeleteBucketPolicy"
+            - "PutBucketAcl"
+            - "PutBucketPublicAccessBlock"
+            - "DeletePublicAccessBlock"
+
+  EventRuleLambdaChanges:
+    Type: "AWS::Events::Rule"
+    Condition: LambdaDetectionEnabled
+    Properties:
+      Name: !Sub "${Project}-detect-lambda-changes"
+      Description: !Sub "[${Project}] Monitor Lambda function creation, code updates, and permission grants (opt-in)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              FunctionName: "$.detail.requestParameters.functionName"
+              Principal: "$.detail.requestParameters.principal"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🧰 FunctionName": <FunctionName>,
+                "👤 Principal": <Principal>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "lambda.amazonaws.com"
+          # Use prefix matchers to future-proof against API version suffixes
+          # (CloudTrail records eventName as e.g. CreateFunction20150331,
+          # UpdateFunctionCode20150331v2 - new API versions silently break exact matches).
+          eventName:
+            - prefix: "CreateFunction"
+            - prefix: "UpdateFunctionCode"
+            - prefix: "AddPermission"
+            - prefix: "CreateFunctionUrlConfig"
+            - prefix: "UpdateFunctionUrlConfig"
+
+  EventRuleSSOChanges:
+    Type: "AWS::Events::Rule"
+    Condition: SSODetectionEnabled
+    Properties:
+      Name: !Sub "${Project}-detect-sso-changes"
+      Description: !Sub "[${Project}] Monitor IAM Identity Center (SSO) permission set / account assignment changes (opt-in, tenant region only)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              InstanceArn: "$.detail.requestParameters.instanceArn"
+              PermissionSetArn: "$.detail.requestParameters.permissionSetArn"
+              TargetId: "$.detail.requestParameters.targetId"
+              PrincipalId: "$.detail.requestParameters.principalId"
+              PrincipalType: "$.detail.requestParameters.principalType"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "🏢 InstanceArn": <InstanceArn>,
+                "🪪 PermissionSetArn": <PermissionSetArn>,
+                "🎯 TargetId": <TargetId>,
+                "👤 PrincipalId": <PrincipalId>,
+                "🔖 PrincipalType": <PrincipalType>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "sso.amazonaws.com"
+          eventName:
+            - "CreateAccountAssignment"
+            - "DeleteAccountAssignment"
+            - "CreatePermissionSet"
+            - "DeletePermissionSet"
+            - "UpdatePermissionSet"
+
+  EventRuleSelfProtection:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Name: !Sub "${Project}-detect-self-stack-tampering"
+      Description: !Sub "[${Project}] Detect tampering with ASSK CloudFormation stacks (DeleteStack, UpdateTerminationProtection)"
+      State: "ENABLED"
+      Targets:
+        - Arn:
+            Ref: CtAlertingTopic
+          Id: CtAlertingTopic
+          InputTransformer:
+            InputPathsMap:
+              EventId: "$.id"
+              EventTime: "$.detail.eventTime"
+              EventName: "$.detail.eventName"
+              EventAccountId: "$.account"
+              EventSourceIp: "$.detail.sourceIPAddress"
+              EventRegion: "$.region"
+              EventBlame: "$.detail.userIdentity.principalId"
+              EventBlameDetails: "$.detail.userIdentity.sessionContext.sessionIssuer.userName"
+              StackName: "$.detail.requestParameters.stackName"
+            InputTemplate: |
+              {
+                "🆔 EventId": <EventId>,
+                "🕑 EventTime": <EventTime>,
+                "👉 EventName": <EventName>,
+                "🧾 EventAccountId": <EventAccountId>,
+                "🌐 EventSourceIp": <EventSourceIp>,
+                "🌏 EventRegion": <EventRegion>,
+                "👨‍🏭 EventBlame": <EventBlame>,
+                "📃 EventBlameDetails": <EventBlameDetails>,
+                "📦 StackName": <StackName>
+              }
+      EventPattern:
+        detail-type:
+          - "AWS API Call via CloudTrail"
+        detail:
+          eventSource:
+            - "cloudformation.amazonaws.com"
+          eventName:
+            - "DeleteStack"
+            - "UpdateTerminationProtection"
+          # CloudTrail records requestParameters.stackName as either the literal
+          # stack name OR a full ARN, depending on how the caller invoked the API.
+          # Match both forms via prefix + wildcard.
+          requestParameters:
+            stackName:
+              - prefix: !Sub "${Project}-"
+              - wildcard: !Sub "*:stack/${Project}-*"
+
+  SnsCmk:
+    Type: "AWS::KMS::Key"
+    Condition: SnsEncryptionEnabled
+    # Explicit Delete to honor `make tear-down`. KMS will still apply its standard
+    # 7-30 day scheduled-deletion window, so accidental deletion remains recoverable.
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      Description: !Sub "[${Project}] CMK for SNS alerting topic encryption (local stack)"
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: "EnableIAMUserPermissions"
+            Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+          - Sid: "AllowEventBridgeAndCloudWatchPublish"
+            Effect: "Allow"
+            Principal:
+              Service:
+                - "events.amazonaws.com"
+                - "cloudwatch.amazonaws.com"
+            Action:
+              - "kms:GenerateDataKey*"
+              - "kms:Decrypt"
+            Resource: "*"
+          - Sid: "AllowChatbotDecrypt"
+            # AWS Chatbot needs kms:Decrypt to deliver encrypted SNS messages
+            # to Slack/Teams. Without this, enabling SNS encryption silently
+            # breaks Chatbot notifications.
+            Effect: "Allow"
+            Principal:
+              Service: "chatbot.amazonaws.com"
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey*"
+            Resource: "*"
+          - !If
+            - HasTrustedAccountIds
+            - Sid: "AllowTrustedAccountsPublish"
+              Effect: "Allow"
+              Principal:
+                AWS: !Ref TrustedAccountIds
+              Action:
+                - "kms:GenerateDataKey*"
+                - "kms:Decrypt"
+              Resource: "*"
+            - !Ref "AWS::NoValue"
+      Tags:
+        - Key: "Project"
+          Value: !Ref Project
+
+  SnsCmkAlias:
+    Type: "AWS::KMS::Alias"
+    Condition: SnsEncryptionEnabled
+    Properties:
+      AliasName: !Sub "alias/${Project}-sns-local"
+      TargetKeyId: !Ref SnsCmk
+
   CtAlertingTopic:
     # https://aws.amazon.com/premiumsupport/knowledge-center/cloudwatch-receive-sns-for-alarm-trigger/
     Type: "AWS::SNS::Topic"
     Properties:
       DisplayName: !Sub "[${AWS::AccountId}] Security Alarm"
       TopicName: !Sub "${Project}-alarm-topic-${AWS::Region}"
+      KmsMasterKeyId: !If
+        - SnsEncryptionEnabled
+        - !Ref SnsCmk
+        - !Ref "AWS::NoValue"
       Subscription:
         - Protocol: email
           Endpoint: !Ref AlarmRecipient
@@ -815,17 +1398,20 @@ Resources:
     Properties:
       PolicyDocument:
         Statement:
+          # Read + publish only for in-account principals.
+          # We intentionally do NOT grant sns:Subscribe via the topic policy:
+          # a compromised in-account principal could otherwise add an attacker
+          # email/HTTPS subscriber and silently exfiltrate every security alert.
+          # Subscribing additional recipients still works via IAM-granted
+          # sns:Subscribe (the legitimate admin flow).
+          # Destructive actions (DeleteTopic, SetTopicAttributes, AddPermission,
+          # RemovePermission) are likewise NOT granted here - they require IAM.
           - Sid: "__default_statement_ID"
             Effect: "Allow"
             Principal:
               AWS: "*"
             Action:
               - "sns:GetTopicAttributes"
-              - "sns:SetTopicAttributes"
-              - "sns:AddPermission"
-              - "sns:RemovePermission"
-              - "sns:DeleteTopic"
-              - "sns:Subscribe"
               - "sns:ListSubscriptionsByTopic"
               - "sns:Publish"
               - "sns:Receive"


### PR DESCRIPTION
Closes #32.

## Summary

This PR implements every item the maintainer accepted on [#32](https://github.com/zoph-io/aws-security-survival-kit/issues/32) (thanks to @devedge09 for the original proposal), then applies a security architect review pass and the operational fixes surfaced by a real dogfood deploy.

- **+9 new EventBridge detections** (3 always-on, 6 opt-in via CloudFormation parameters), plus a self-protection rule per stack.
- **SNS topic hardened**: destructive actions (`DeleteTopic`, `SetTopicAttributes`, `AddPermission`, `RemovePermission`) and `Subscribe` removed from the wildcard-Principal statement. Subscribe via topic policy was a real exfil risk — a compromised in-account principal could silently add an attacker email endpoint and receive every alert.
- **Optional SNS KMS CMK** behind `EnableSnsEncryption=true`, with `chatbot.amazonaws.com` in the key policy so AWS Chatbot keeps working.
- **`AccessDeniedThreshold` parameter** (default `25`, was hard-coded `1`) to reduce alert fatigue.
- **Self-protection rule**: alerts on `DeleteStack` / `UpdateTerminationProtection` against `${Project}-*` (matches both stack-name and stack-ARN forms via `prefix` + `wildcard`). README is honest about the race condition on `DeleteStack` — the rule's SNS target is in the same stack being deleted.
- **Stack termination protection** is now enabled by `make deploy` and disabled by `make tear-down`.

## Account-level hardening fix (account_level_security)

The pre-existing `account_level_security` target had two real bugs:

1. **Region scope was wrong.** EBS encryption, AMI block, snapshot block and IMDSv2 defaults are **region-scoped** APIs — they were only being applied to `LocalAWSRegion`, leaving every other region unhardened. They now loop across every enabled region (`describe-regions` with `opt-in-status` filter). S3 Block Public Access remains the single account-scoped call.
2. **Not wired into deploy.** The `deploy: #account_level_security` dependency was commented out, so the "Secure by default" README claim was untrue for fresh installs. Now wired in.

## Security architect review fixes (issue #32 follow-up)

| Finding | Fix |
| --- | --- |
| `EventRuleSecurityGroupOpenAdminPorts` `cidrIp: "*.*.*.*/*"` was an invalid EventBridge pattern (silently matched nothing) | Removed; rule split into `…-ipv4` (`0.0.0.0/0`) and `…-ipv6` (`::/0`) |
| Lambda `eventName` exact-matching is fragile against API version suffixes (`CreateFunction20150331v2` etc.) | Switched to `prefix` matchers |
| Self-protection `requestParameters.stackName` only caught literal names, missing ARN form | `prefix: ${Project}-` + `wildcard: *:stack/${Project}-*` |
| `EventRuleConfigChanges` and `EventRuleSecurityGroupChanges` had no `InputTransformer` (raw CloudTrail JSON) | Standard emoji-keyed transformer added |
| `EventRuleRolesAnywhereTrustChanges` was the only rule without emoji keys | Aligned with the project convention |
| Three existing rules (`GetCallerIdentity`, `BatchGetSecretValue`, `GetPasswordData`) are extremely noisy in real accounts | New `Enable*Detection` parameters (default `true` for back-compat) so users can flip them off |
| AWS Chatbot silently breaks when SNS encryption is enabled | Added `AllowChatbotDecrypt` statement to the CMK key policy |

## Dogfood-driven Makefile improvements

Found while live-deploying to my personal account under `aws-vault`:

- `Profile=""` → `--profile ""` clashed with environment credentials. `PROFILE_FLAG := $(if $(strip $(Profile)),--profile $(Profile),)` emits the flag only when set. Works with `aws-vault exec`, IRSA, ECS task role, and named profiles.
- A single down region (`me-south-1` during my run) stalled the hardening loop for minutes. Added `--cli-connect-timeout 10 --cli-read-timeout 15` on every per-region call, plus a `SkipRegions="me-south-1 …"` Make variable for permanent exclusions.
- `cfn-local.yml` is now >51,200 bytes (CloudFormation inline limit). Added optional `LocalS3Bucket` / `GlobalS3Bucket` variables that inject `--s3-bucket … --s3-prefix assk` when set.

## README

- **Rationale rewritten** for newcomers — explains the gap between AWS logging and AWS alerting, lists concrete scenarios GuardDuty does not cover, states the 5 design principles, and explicitly says the kit is not a SIEM.
- New opt-in detection table with default values and "when to enable" guidance.
- New "Existing detections you may want to turn OFF" table for the back-compat-on noisy rules.
- Honest self-protection caveat.
- AccessDenied alarm semantics spelled out (`Period=3600s` × `EvaluationPeriods=2`).
- SNS+CMK cost clarified (~\$2/month for two CMKs, plus per-call charges).
- `LocalAWSRegion` description corrected.

## Validation

- `cfn-lint cfn-local.yml cfn-global.yml` — clean, no warnings.
- `make -n deploy` — clean expansion, all parameters wired correctly.
- **Live dogfood deploy to account `567589703415` (`aws-vault exec zoph-admin`):**
  - `aws-security-survival-kit-local` (eu-west-1): `UPDATE_COMPLETE`, 27 resources, termination protection ON.
  - `aws-security-survival-kit-global` (us-east-1): `UPDATE_COMPLETE`, 10 resources, termination protection ON.
  - 28 regions hardened in ~103s; `me-south-1` cleanly skipped.
  - New EventBridge rules verified `ENABLED` via `aws events list-rules`.
  - Tightened SNS topic policy confirmed via `aws sns get-topic-attributes`.

## Follow-up

[#33](https://github.com/zoph-io/aws-security-survival-kit/issues/33) tracks 17 additional high-signal detections (Persistence / Data-exfil / Network exposure / SSO / Recon) that came out of the same review but are out of scope for this PR. They can be cherry-picked into small follow-up PRs.

## Test plan

- [x] `cfn-lint` passes on both templates.
- [x] `make -n deploy` produces expected commands.
- [x] Live deploy to personal AWS account succeeds.
- [x] All new EventBridge rules deployed and `ENABLED`.
- [x] SNS topic policy verified to be the tightened version.
- [x] Termination protection verified ON on both stacks.
- [ ] (Maintainer) Verify a trigger event (e.g. `aws sts get-caller-identity`) actually delivers an email — should be expected within a few minutes of the deploy.

Made with [Cursor](https://cursor.com)